### PR TITLE
fix: 🐛 if a validator strategy returns two ways use the first

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -70,11 +70,15 @@ export function format(pixKey, as = null) {
 
 	let useAs = validate(pixKey)
 	if (useAs.length > 1) {
+		if(as) {
 		if (useAs.includes(as)) {
 			useAs = as
 		} else {
 			return null
 		}
+	}else {
+		useAs = useAs[0]
+	}
 	} else if (!useAs.length) {
 		return null
 	} else {
@@ -98,4 +102,4 @@ export function format(pixKey, as = null) {
 	}
 }
 
-export { PIX_KEY_CPF, PIX_KEY_CNPJ, PIX_KEY_RANDOM, PIX_KEY_EMAIL, PIX_KEY_PHONE }
+export { PIX_KEY_CNPJ, PIX_KEY_CPF, PIX_KEY_EMAIL, PIX_KEY_PHONE, PIX_KEY_RANDOM }


### PR DESCRIPTION
With this library, I encountered an issue where certain inputs, such as a CPF could also resemble a phone number. For instance:
```
CPF: 00000000000
```
The validator mistakenly returns: ```['cpf', 'phone']```

This situation poses a problem when attempting to normalize the input for a PIX transaction. For example:
```normalize('000000000')```
Without passing a strategy explicitly, the ```"as"``` parameter in the normalize method will be null, leading to a validation error.

The solution is to return the first strategy on validator to normalize.